### PR TITLE
Update ggpowindow.ui to match ggpowindow_ui.py

### DIFF
--- a/ggpo/gui/ui/ggpowindow.ui
+++ b/ggpo/gui/ui/ggpowindow.ui
@@ -109,7 +109,7 @@
      <x>0</x>
      <y>0</y>
      <width>810</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAction">
@@ -169,6 +169,7 @@
     <addaction name="uiDisableAutoColorNicks"/>
     <addaction name="uiHideGamesWithoutRomAct"/>
     <addaction name="menuLogging"/>
+    <addaction name="uiFilterFavoriteLobbies"/>
    </widget>
    <widget class="QMenu" name="menuAbout">
     <property name="title">
@@ -501,6 +502,14 @@
   <action name="uiGNGWebAct">
    <property name="text">
     <string>FightCade website</string>
+   </property>
+  </action>
+  <action name="uiFilterFavoriteLobbies">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Filter Favorite Lobbies</string>
    </property>
   </action>
  </widget>

--- a/ggpo/gui/ui/ggpowindow_ui.py
+++ b/ggpo/gui/ui/ggpowindow_ui.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'my_ggpowindow.ui'
+# Form implementation generated from reading ui file 'ggpowindow.ui'
 #
-# Created: Sun Jan 18 09:45:54 2015
+# Created: Wed Feb 11 06:01:04 2015
 #      by: PyQt4 UI code generator 4.11.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -233,8 +233,8 @@ class Ui_MainWindow(object):
         self.menuSetting.addAction(self.uiShowTimestampInChatAct)
         self.menuSetting.addAction(self.uiDisableAutoColorNicks)
         self.menuSetting.addAction(self.uiHideGamesWithoutRomAct)
-        self.menuSetting.addAction(self.uiFilterFavoriteLobbies)
         self.menuSetting.addAction(self.menuLogging.menuAction())
+        self.menuSetting.addAction(self.uiFilterFavoriteLobbies)
         self.menuAbout.addAction(self.uiSRKForumAct)
         self.menuAbout.addAction(self.uiSRKWikiAct)
         self.menuAbout.addAction(self.uiJPWikiAct)


### PR DESCRIPTION
The version of ggpowindow.ui in the repository doesn't contain the
recent changes reflected in ggpowindow_ui.py, breaking things if the
_ui.py file was regenerated from the .ui file during build.  I've
recreated the changes in the .ui file that will generate a _ui.py file
matching the current one.