### PR TITLE
Fix startup error with conflicting Python paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 import platform
 
 if platform.system() == 'Darwin':
-    sys.path.append("../Resources/lib/python2.7/site-packages/")
+    sys.path.insert(1, "../Resources/lib/python2.7/site-packages/")
 
 import sip
 # Tell qt to return python string instead of QString


### PR DESCRIPTION
Fightcade can fail on an ImportError if the user already has another version of python in the PATH. Changing this line ensures that the site-packages in Resources/ gets loaded instead.
